### PR TITLE
Removed print object function

### DIFF
--- a/signing.py
+++ b/signing.py
@@ -26,20 +26,6 @@ import tuf.util
 import canonicaljson as json
 
 
-def print_object(obj_desc, object):
-  # Return on prints, potentially remove this function
-  #return
-  verbose = 0
-  if (verbose != 0):
-  	return
-  print obj_desc + "\n==============================\n" 
-  print object
-  print "\n==============================\n" 
-
-
-
-
-
 def sign_json(data):
   """
   <Purpose>


### PR DESCRIPTION
The print object function was for debug purposes and should be removed.
